### PR TITLE
Add requirements.txt which worked for me on OSX (knightmare2600)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+gin
+argparse
+colorama
+click
+requests
+tabulate
+cmd2
+tqdm


### PR DESCRIPTION
Managed to get the tool running on a python3 install via home brew on OSX High Sierra with the attached (WIP) requirements.txt and a pip3 install -r requirements.txt